### PR TITLE
fix: iOS status bar background color

### DIFF
--- a/src/components/NotFoundCard.vue
+++ b/src/components/NotFoundCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-gray-50 dark:bg-black flex flex-col font-mono text-gray-900 dark:text-gray-100">
+  <div class="min-h-screen flex flex-col">
     <main class="flex-grow flex items-center justify-center py-10">
       <div
         class="w-full max-w-md mx-4 sm:mx-auto rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-950 shadow-sm overflow-hidden"

--- a/src/components/ProfileCard.vue
+++ b/src/components/ProfileCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-gray-50 dark:bg-black flex flex-col font-mono text-gray-900 dark:text-gray-100">
+  <div class="min-h-screen flex flex-col">
     <main class="flex-grow flex items-center justify-center py-10">
       <div
         class="w-full max-w-2xl mx-4 sm:mx-auto rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-950 shadow-sm overflow-hidden"

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -24,7 +24,7 @@ const ogImage = new URL('/images/og.image.png', Astro.site);
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>{title}</title>
     <meta name="robots" content={robotsContent} />
     <meta name="description" content={description} />
@@ -39,7 +39,7 @@ const ogImage = new URL('/images/og.image.png', Astro.site);
     />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
   </head>
-  <body>
+  <body class="bg-gray-50 dark:bg-black font-mono text-gray-900 dark:text-gray-100">
     <slot />
   </body>
 </html>


### PR DESCRIPTION
Sets the background color on the body and adds viewport-fit=cover to the viewport meta tag to ensure the status bar color matches the theme on modern iOS versions.